### PR TITLE
addCalendarActivity Google Account prompt

### DIFF
--- a/ClassManager/app/src/main/java/com/example/camdavejakerob/classmanager/AttendanceActivity.java
+++ b/ClassManager/app/src/main/java/com/example/camdavejakerob/classmanager/AttendanceActivity.java
@@ -268,9 +268,12 @@ public class AttendanceActivity extends AppCompatActivity {
         if (endPM && endHour < 13)
             endHour += 12;
 
-        if (currentHour < startHour || currentHour > endHour) {
+        if (currentHour < startHour || currentHour > endHour)
+        {
             // Toast.makeText(this, "Class is not active yet.", Toast.LENGTH_LONG).show();
-            Toast.makeText(this, "c: " + currentHour + ", s: " + startHour + ", e: " + endHour, Toast.LENGTH_LONG).show();
+            Toast.makeText(this,
+                    "Class is between " + startHour + ":" + startMin + " and " + endHour + ":" + endMin,
+                    Toast.LENGTH_LONG).show();
             return false;
         }
 

--- a/ClassManager/app/src/main/java/com/example/camdavejakerob/classmanager/CalendarActivity.java
+++ b/ClassManager/app/src/main/java/com/example/camdavejakerob/classmanager/CalendarActivity.java
@@ -174,7 +174,14 @@ public class CalendarActivity extends AppCompatActivity
 
     public static String getGoogleAccount(Context context)
     {
-        String accountName = null;
+        if (accountCredential == null)
+        {
+            accountCredential = GoogleAccountCredential.usingOAuth2(
+                context, Arrays.asList(SCOPES))
+                .setBackOff(new ExponentialBackOff());
+        }
+        if (accountCredential == null)
+            return null;
 
         Account[] accounts = accountCredential.getAllAccounts();
         if (accounts == null || accounts.length < 1)
@@ -200,6 +207,13 @@ public class CalendarActivity extends AppCompatActivity
 
     public static void addCalendarEvent(Context context, Class course)
     {
+        if (accountCredential == null)
+        {
+            accountCredential = GoogleAccountCredential.usingOAuth2(
+                    context, Arrays.asList(SCOPES))
+                    .setBackOff(new ExponentialBackOff());
+        }
+
         prefs = context.getSharedPreferences(MY_PREFS_NAME, MODE_PRIVATE);
         CALENDAR_EVENTS_ENABLED = prefs.getBoolean(CALENDAR_EVENT_PREF, true);
         editor = prefs.edit();


### PR DESCRIPTION
addCalendarActivity should prompt user to add a Google Account if one cannot be found.

Crash issues should be solved. Tested on a fresh emulator install with no Google accounts